### PR TITLE
django 2.2 - 3.0 compatibility removal setup cfg universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1


### PR DESCRIPTION
extra step to say that we're not expecting to keep py2 support around (removal of the universal flag for the wheel creation). 