### PR TITLE
Chore/django3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,26 @@ matrix:
       env: TOXENV=django22-py36
     - python: 3.6
       env: TOXENV=django30-py36
+    - python: 3.6
+      env: TOXENV=django31-py36
+    - python: 3.6
+      env: TOXENV=django32-py36
     - python: 3.7
       env: TOXENV=django22-py37
     - python: 3.7
       env: TOXENV=django30-py37
+    - python: 3.7
+      env: TOXENV=django31-py37
+    - python: 3.7
+      env: TOXENV=django32-py37
     - python: 3.8
       env: TOXENV=django228-py38
     - python: 3.8
       env: TOXENV=django30-py38
-
+    - python: 3.8
+      env: TOXENV=django31-py38
+    - python: 3.8
+      env: TOXENV=django32-py38
 
 before_install:
   - python -m pip install codecov tox

--- a/disposable_email_checker/validators.py
+++ b/disposable_email_checker/validators.py
@@ -74,8 +74,8 @@ class DisposableEmailChecker(object):
         )
         return get_callable(loader)()
 
-    def chunk(self, l, n):
-        return (l[i : i + n] for i in range(0, len(l), n))
+    def chunk(self, emails, n):
+        return (emails[i : i + n] for i in range(0, len(emails), n))
 
 
 validate_disposable_email = DisposableEmailChecker()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django>=2.2,<3.1
+django>=2.2,<=3.2
 wheel>=0.30.0
 # Additional requirements go here

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django22-py{35,36,37}, django228-py{38}, django30-py{36,37,38}
+envlist = django22-py{35,36,37}, django228-py{38}, django30-py{36,37,38}, django31-py{36,37,38}, django32-py{36,37,38}
 
 
 [testenv]
@@ -15,4 +15,6 @@ deps =
     django22: django>=2.2,<3.0
     django228: django>=2.2.8,<3.0
     django30: django>=3.0,<3.1
+    django31: django>=3.1,<3.2
+    django32: django>=3.2,<4.0
     -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
This pull request adds explicit support for Django 3.1 and 3.2
No code change required, only adding the new django versions to the list of tests performed with Tox