### PR TITLE
Django 4.0 - 4.2 Compatibility

### DIFF
--- a/disposable_email_checker/validators.py
+++ b/disposable_email_checker/validators.py
@@ -2,7 +2,7 @@
 
 import re
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
@@ -36,7 +36,7 @@ class DisposableEmailChecker(object):
         self.BDEA_TIMEOUT = getattr(settings, "BDEA_TIMEOUT", 5)
 
     def __call__(self, value):
-        value = force_text(value)
+        value = force_str(value)
 
         # Catch invalid emails before we check if they're disposable
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django>=2.2,<=3.2
+django>=2.2,<=4.2.9
 wheel>=0.30.0
 # Additional requirements go here

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django22-py{35,36,37}, django228-py{38}, django30-py{36,37,38}, django31-py{36,37,38}, django32-py{36,37,38}
+envlist = django22-py{35,36,37}, django228-py{38}, django30-py{36,37,38}, django31-py{36,37,38}, django32-py{36,37,38}, django40-py{38,39,310}, django41-py{38,39,310,311}, django42-py{38,39,310,311,312}
 
 
 [testenv]
@@ -8,6 +8,10 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/disposable_email_checker
 commands = coverage run --source disposable_email_checker runtests.py
@@ -17,4 +21,7 @@ deps =
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
     django32: django>=3.2,<4.0
+    django40: django>=4.0,<4.1
+    django41: django>=4.1,<4.2
+    django42: django>=4.2,<5.0
     -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
Updated references to removed `force_text` to `force_str`, for which it was an alias, and updated tox.ini with new supported versions.